### PR TITLE
Changed name of disk checks

### DIFF
--- a/templates/baseservices.erb
+++ b/templates/baseservices.erb
@@ -19,7 +19,7 @@ define service {
 define service {
     host_name           <%= host_name %>
     service_description All_Disks_Usage
-    check_command       check_nrpe!check_all_disks_param!noarg
+    check_command       check_nrpe!check_all_disks!noarg
     use                 <%= use %>
 }
 


### PR DESCRIPTION
I found that when I used the puppet-nrpe module in combination with the icinga module these particular alerts didn't align, the name in the nrpe configuration didn't have the '_param' at the end. 

I changed these to match, but perhaps this is part of a bigger plan that just isn't complete so feel free to reject. As-is though, the nrpe + icinga modules don't work out of the box as this check fails. 
