### PR TITLE
fixed inconsistency with check_all_disks naming

### DIFF
--- a/templates/baseservices.erb
+++ b/templates/baseservices.erb
@@ -19,7 +19,7 @@ define service {
 define service {
     host_name           <%= host_name %>
     service_description All_Disks_Usage
-    check_command       check_nrpe!check_all_disks!noarg
+    check_command       check_nrpe!check_all_disks_param!noarg
     use                 <%= use %>
 }
 


### PR DESCRIPTION
The name of the Check for disk space was inconsistend.

In 
./templates/nrpe_cfg/nrpe-check_disk.cfg.erb
it was called check_all_disks_param
but in 
./templates/baseservices.erb
it was called check_all_disks
therefore the template based checks of check_all_disks will fail.
