### PR TITLE
fixed missing line break if supplying a host_parent

### DIFF
--- a/templates/host.erb
+++ b/templates/host.erb
@@ -7,6 +7,6 @@ define host{
     address    <%= ip %>
     use        <%= use %>
 <% if ! (/^(none|)$/i =~ host_parent) then -%>
-    parents <%= host_parent -%>
+    parents <%= host_parent %>
 <% end -%>
 }


### PR DESCRIPTION
if supplying a host_parent, the closing } would be at the end of the parents line, thus not being recognized as the closing for the host { section.
