### PR TITLE
fixing the dependency cycle that is created when using icinga::command.

### DIFF
--- a/manifests/command.pp
+++ b/manifests/command.pp
@@ -4,7 +4,7 @@
 #
 define icinga::command ( $command_line  = '' , $ensure = 'present' ) {
 
-  require icinga
+  include icinga
 
   file { "${icinga::customconfigdir}/commands/${name}.cfg":
     ensure  => $ensure,


### PR DESCRIPTION
Example after creating a icinga::command

``` puppet
  icinga::command { 'check_https':
    command_line => '$USER1$/check_http -S -H $HOSTADDRESS$'
  }
```

![dotfile](https://f.cloud.github.com/assets/129312/288295/18b2b980-9270-11e2-8a72-8bc33a38d97e.png)

``` dot
digraph Resource_Cycles {
  label = "Resource Cycles"
  "File[/etc/icinga/auto.d/commands/check_https.cfg]" -> "Service[icinga]" -> "Class[Icinga]" ->
  "Icinga::Command[check_https]" -> "File[/etc/icinga/auto.d/commands/check_https.cfg]"
}
```

(File[/etc/icinga/auto.d/commands/check_https.cfg] => Service[icinga] => Class[Icinga] => Icinga::Command[check_https]
=> File[/etc/icinga/auto.d/commands/check_https.cfg])
