### PR TITLE
install nrpe-plugin after icinga itself

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -345,8 +345,9 @@ class icinga (
 
   ### Managed resources
   package { 'nrpe-plugin':
-    ensure => $icinga::manage_package,
-    name   => $icinga::nrpepluginpackage,
+    ensure  => $icinga::manage_package,
+    name    => $icinga::nrpepluginpackage,
+    require => Package['icinga'], # this has to be installed after icinga, to avoid the Recommend:nagios3 pulling in the wrong server
   }
 
   package { 'icinga':


### PR DESCRIPTION
On wheezy, it is possible that installing the nrpe-plugin pulls
in nagios3 as preferred recommendation. If icinga is already installed,
the recommendation is satisfied and nagios3 is not installed.
