### PR TITLE
fix icinga::cgi

### DIFF
--- a/manifests/cgi.pp
+++ b/manifests/cgi.pp
@@ -1,16 +1,16 @@
 class icinga::cgi {
-
   require icinga
 
   package { 'icinga-gui':
     ensure  => $icinga::manage_package,
+    name    => $icinga::icingacgipackage,
     require => Package['icinga'],
   }
 
   # QUICK AND DIRTY
-  file { '/etc/icinga/apache2.conf':
+  file { $icinga::apache_icingacgi_config:
     ensure => link,
-    target => $icinga::apache_icingacgi_config,
+    target => $icinga::apache_icingacgi_target,
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -201,6 +201,7 @@ class icinga (
   $icingacgipackage            = params_lookup( 'icingacgipackage' ),
   $enable_icingacgi            = params_lookup( 'enable_icingacgi' ),
   $apache_icingacgi_config     = params_lookup( 'apache_icingacgi_config' ),
+  $apache_icingacgi_target     = params_lookup( 'apache_icingacgi_target' ),
   $check_external_commands     = params_lookup( 'check_external_commands' ),
   $plugins                     = params_lookup( 'plugins' ),
   $use_ssl                     = params_lookup( 'use_ssl' ),

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -84,6 +84,10 @@ class icinga::params {
     default                   => '/etc/httpd/conf.d/icinga.conf',
   }
 
+  $apache_icingacgi_target = $::operatingsystem ? {
+    default                   => '/etc/icinga/apache2.conf',
+  }
+
   ### ICINGA variables
   ####################################################
   $grouplogic = ''


### PR DESCRIPTION
the original version would have created a circular symlink from target
-> config -> target.
