### PR TITLE
Set up Icinga-Web on/for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ For detailed info about the logic and usage patterns of Example42 modules check 
           audit_only => true
         }
 
+* Enable icinga-web
+
+        class { '::icinga':
+          enable_idoutils           => true,
+          enable_icingaweb          => true,
+          manage_repos              => true,
+          enable_debian_repo_legacy => false,
+        }
+
+  The last option exists for legacy reasons only.
+
 
 ## USAGE - Overrides and Customizations
 * Use custom sources for main config file 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -229,6 +229,12 @@ class icinga::params {
     default => '/var/log/icinga/icinga.log',
   }
 
+  if $::operatingsystem =~ /(?i:Debian|Ubuntu|Mint)/ {
+    $enable_debian_repo_legacy = true
+  } else {
+    $enable_debian_repo_legacy = false
+  }
+
   # General Settings
   $my_class = ''
   $source = ''

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -1,0 +1,44 @@
+# = Class: icinga::repository
+#
+# This class configures the repository for Icinga
+#
+#
+class icinga::repository {
+
+  if ( $::icinga::bool_enable_debian_repo_legacy != true and
+       $::operatingsystem =~ /(?i:Ubuntu|Mint)/ and
+       $::icinga::bool_manage_repos == true
+  ) {
+    # The repos as suggested by icinga:
+    # https://wiki.icinga.org/display/howtos/Setting+up+Icinga+Web+on+Ubuntu
+    #
+    apt::repository { 'icinga-web':
+      url        => 'http://ppa.launchpad.net/formorer/icinga-web/ubuntu',
+      distro     => 'precise',
+      repository => 'main',
+    }
+
+    apt::repository { 'icinga':
+      url        => 'http://ppa.launchpad.net/formorer/icinga/ubuntu',
+      distro     => 'precise',
+      repository => 'main',
+    }
+
+    apt::key { 'icinga':
+      keyserver => 'keyserver.ubuntu.com',
+      fingerprint => '36862847',
+    }
+  }
+
+  if ( $::icinga::bool_enable_debian_repo_legacy == true or
+     ($::operatingsystem =~ /(?i:Debian)/ and $::icinga::bool_manage_repos == true)
+  ) {
+    # Perhaps on Debian we should use the packages from debmon.org
+    apt::repository { 'icinga':
+      url        => 'http://icingabuild.dus.dg-i.net/',
+      distro     => "icinga-web-${::lsbdistcodename}",
+      repository => 'main',
+    }
+  }
+
+}


### PR DESCRIPTION
I tested and setup Icinga-Web for Ubuntu. I determined (or rather figured) that the Debian repository simply isn't compatible with Ubuntu due to dependency conflicts as I more or less already found out in #6.

On IRC I was suggested to use the packaging from debmon.org for Debian, but didn't feel comfortable changing that at the risk of breaking backwards compatibility. As far as I can see this PR provides full Backwards Compatibility, at the cost of having two unfortunate default values.
