### PR TITLE
Allow extra perms on /var/lib/icinga/rw

### DIFF
--- a/manifests/skel.pp
+++ b/manifests/skel.pp
@@ -177,11 +177,13 @@ class icinga::skel {
 
   # icinga group needs permission to write in /var/lib/icinga/rw
   if $::operatingsystem =~ /(?i:Debian|Ubuntu|Mint)/ {
-    file { '/var/lib/icinga/rw':
+    @file { '/var/lib/icinga/rw':
       ensure  => directory,
       mode    => '0770',
       require => Package['icinga'],
     }
+
+    realize ( File['/var/lib/icinga/rw'] )
   }
 
 }


### PR DESCRIPTION
The Icinga module rightfully sets the proper fileperms on
the /var/lib/icinga/rw directory. However, I'm running
Icinga under a different user/group (mod_ruid2 ftw), and
as such needed to set a different group on the aforementioned
directory.

Therefore, I made the file resource a virtual one, allowing
one to overwrite it:

  File <| title == '/var/lib/icinga/rw' |> {
    owner   => 'nagios',
    group   => 'icingagui',
    recurse => false,
    backup  => false,
    require => User[ 'icingagui' ],
    notify  => Service[ 'apache' ]
  }

  realize( File['/var/lib/icinga/rw'] )
