### PR TITLE
wiki no longer requires precise distro

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -9,21 +9,19 @@ class icinga::repository {
        $::operatingsystem =~ /(?i:Ubuntu|Mint)/ and
        $::icinga::bool_manage_repos == true
   ) {
-    apt::repository { 'icinga-web':
-      url        => 'http://ppa.launchpad.net/formorer/icinga-web/ubuntu',
-      distro     => $::lsbdistcodename,
-      repository => 'main',
-    }
-
-    apt::repository { 'icinga':
-      url        => 'http://ppa.launchpad.net/formorer/icinga/ubuntu',
-      distro     => $::lsbdistcodename,
-      repository => 'main',
-    }
-
-    apt::key { 'icinga':
-      keyserver => 'keyserver.ubuntu.com',
-      fingerprint => '36862847',
+    apt::repository {
+      'icinga-web':
+        url        => 'http://ppa.launchpad.net/formorer/icinga-web/ubuntu',
+        distro     => $::lsbdistcodename,
+        repository => 'main',
+        keyserver  => 'keyserver.ubuntu.com',
+        key        => '36862847';
+      'icinga':
+        url        => 'http://ppa.launchpad.net/formorer/icinga/ubuntu',
+        distro     => $::lsbdistcodename,
+        repository => 'main',
+        keyserver  => 'keyserver.ubuntu.com',
+        key        => '36862847';
     }
   }
 


### PR DESCRIPTION
https://wiki.icinga.org/display/howtos/Setting+up+Icinga+Web+on+Ubuntu no longer requires you to use precise repo.. lets clean this up.. 
